### PR TITLE
Fixes type mismatch for sample binary

### DIFF
--- a/cmd/killtree/main.go
+++ b/cmd/killtree/main.go
@@ -15,6 +15,6 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-		psutil.KillTree(pid, 0)
+		psutil.TerminateTree(pid, 0)
 	}
 }


### PR DESCRIPTION
The sample binary tries to call `psutil.KillTree` which takes a ProcessHandle (and is also unexported). This change makes it call `psutil.TerminateTree` instead.